### PR TITLE
Do not rebuild every day

### DIFF
--- a/.github/workflows/basic_test.yml
+++ b/.github/workflows/basic_test.yml
@@ -1,0 +1,20 @@
+name: Docker Image CI
+
+on:
+  pull_request:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      -
+        name: Build docker image
+        run: docker build . -t linono_test
+      -
+        name: Run linono in the docker image
+        run: docker run --rm --entrypoint bash linono_test -c "rye run linono"

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -1,12 +1,13 @@
 name: Deploy github page
 
 on:
-    push:
-      branches: ["main"]
-    schedule:
-        - cron: "0 4 * * *" 
+  workflow_run:
+    workflows: [push-to-docker]
+    types: [completed]
+  schedule:
+    - cron: "0 4 * * *" 
   
-    workflow_dispatch:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -25,21 +26,9 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    container:
+      image: baduit/linono:latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install rustup
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -y | sh
-
-      - name: Install the latest version of rye
-        uses: eifinger/setup-rye@v4
-        with:
-          enable-cache: true
-  
-      - name: Sync dependencies
-        run: rye sync
-
       - name: Generate html
         run: |
           mkdir build

--- a/.github/workflows/push-to-docker.yaml
+++ b/.github/workflows/push-to-docker.yaml
@@ -1,0 +1,35 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: baduit
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: baduit/linono:latest

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ target/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+build/
+
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:24.10
+
+WORKDIR /linono
+COPY . /linono/
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt update
+
+# Install essential
+RUN apt install build-essential -y
+
+# Install Curl to be able to install other tools
+RUN apt install curl -y
+
+# Install rust toolchain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install Rye
+RUN curl -sSf https://rye.astral.sh/get | RYE_INSTALL_OPTION="--yes" bash
+ENV PATH=/root/.rye/shims:$PATH
+
+
+# Build
+RUN rye sync


### PR DESCRIPTION
The idea is to create a docker image only when __main__ is updated, then everyday we just download it run `linono` 

__.gitignore__ is also slightly updated and on PR we just check that we can build the docker image then run the linono